### PR TITLE
feat: auto-collapse expanded messages after configurable timeout

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -138,6 +138,7 @@ def main() -> None:
         'private_rate_limit': float(os.environ.get('PRIVATE_RATE_LIMIT', '1.0')),
         'max_update_frequency': float(os.environ.get('MAX_UPDATE_FREQUENCY', '0.5')),
         'expandable_message_limit': int(os.environ.get('EXPANDABLE_MESSAGE_LIMIT', '280')),
+        'auto_collapse_delay': int(os.environ.get('AUTO_COLLAPSE_DELAY', '60')),
     }
 
     if model in GPT_SEARCH_MODELS and openai_config['web_search_support_annotations']:

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -701,6 +701,33 @@ class ChatGPTTelegramBot:
             reply_markup=_make_collapse_markup(seq),
         )
 
+        # Schedule auto-collapse after timeout
+        auto_collapse_delay = self.config.get('auto_collapse_delay', 60)
+        if auto_collapse_delay > 0:
+            asyncio.ensure_future(self._auto_collapse(context, seq, auto_collapse_delay))
+
+    async def _auto_collapse(self, context: ContextTypes.DEFAULT_TYPE, seq: int, delay: int):
+        """Automatically collapse an expanded message after a delay."""
+        await asyncio.sleep(delay)
+        state = self.expandable_messages.get(seq)
+        if not state or not state['is_expanded'] or state['is_streaming']:
+            return
+        state['is_expanded'] = False
+        state['last_toggled'] = time.time()
+        truncation_limit = self.config['expandable_message_limit']
+        truncated = truncate_text(state['full_text'], truncation_limit)
+        try:
+            await edit_message_with_retry(
+                context,
+                state['chat_id'],
+                str(state['msg_id']),
+                text=truncated,
+                markdown=True,
+                reply_markup=_make_expand_markup(seq),
+            )
+        except Exception:
+            pass  # message may have been deleted or already collapsed
+
     async def handle_collapse_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         query = update.callback_query
         seq = int(query.data.split(':')[1])

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -704,7 +704,11 @@ class ChatGPTTelegramBot:
         # Schedule auto-collapse after timeout
         auto_collapse_delay = self.config.get('auto_collapse_delay', 60)
         if auto_collapse_delay > 0:
-            asyncio.ensure_future(self._auto_collapse(context, seq, auto_collapse_delay))
+            task = asyncio.get_event_loop().create_task(
+                self._auto_collapse(context, seq, auto_collapse_delay)
+            )
+            # Keep a reference to prevent the task from being garbage collected mid-execution
+            state['auto_collapse_task'] = task
 
     async def _auto_collapse(self, context: ContextTypes.DEFAULT_TYPE, seq: int, delay: int):
         """Automatically collapse an expanded message after a delay."""
@@ -744,6 +748,11 @@ class ChatGPTTelegramBot:
 
         state['is_expanded'] = False
         await query.answer()
+
+        # Cancel any pending auto-collapse task
+        task = state.pop('auto_collapse_task', None)
+        if task and not task.done():
+            task.cancel()
 
         # Truncated text is stable — text[:limit] never changes during streaming,
         # so we can collapse immediately without a waiting state.


### PR DESCRIPTION
## Summary

After a message is expanded via "Show more", automatically collapse it back after a configurable delay (default: 60 seconds).

This prevents long messages from cluttering the chat indefinitely when users forget to collapse them.

## Changes

- **`bot/telegram_bot.py`**: Added `_auto_collapse` coroutine that waits for the delay then collapses the message. Scheduled via `asyncio.ensure_future` after a successful expand.
- **`bot/main.py`**: Added `auto_collapse_delay` config key, sourced from `AUTO_COLLAPSE_DELAY` env var (default: `60` seconds).

## Behavior

- Timer starts when user clicks "Show more" (not during streaming)
- If the user manually collapses before the timer fires — nothing happens (state check guards it)
- Set `AUTO_COLLAPSE_DELAY=0` to disable auto-collapse entirely