### PR TITLE
fix: specify libmp3lame codec in pydub MP3 export

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1089,7 +1089,7 @@ class ChatGPTTelegramBot:
             try:
                 audio_track = AudioSegment.from_file(filename)
                 # FIXME do not save to file
-                audio_track.export(filename_mp3, format='mp3')
+                audio_track.export(filename_mp3, format='mp3', codec='libmp3lame', bitrate='128k')
                 logging.info(
                     f'New transcribe request received from user {update.message.from_user.name} '
                     f'(id: {update.message.from_user.id})'


### PR DESCRIPTION
## Problem

When exporting audio to MP3 using pydub 0.25.1, the codec is not inferred automatically in all ffmpeg builds. This results in an invalid or empty MP3 file, which causes the Whisper transcription API to fail.

## Fix

Explicitly pass `codec='libmp3lame'` and `bitrate='128k'` to `AudioSegment.export()`:

```python
# Before
audio_track.export(filename_mp3, format='mp3')

# After  
audio_track.export(filename_mp3, format='mp3', codec='libmp3lame', bitrate='128k')
```

## Why

From pydub docs and ffmpeg behavior: when no codec is specified, pydub passes the format name as the codec hint, but `mp3` is a container/format name — the actual encoder is `libmp3lame`. Some ffmpeg builds fail silently in this case. Explicit codec specification is always safe and portable.